### PR TITLE
Update HTTP status code in OpenAPI spec 

### DIFF
--- a/openapi/model-service-v1.yml
+++ b/openapi/model-service-v1.yml
@@ -263,7 +263,7 @@ paths:
           schema:
             type: string
       responses:
-        "200":
+        "204":
           description: successful operation
 
       security:
@@ -1798,7 +1798,7 @@ paths:
           schema:
             type: string
       responses:
-        "200":
+        "204":
           description: successful operation
       security:
         - Bearer: []

--- a/openapi/model-service-v2.yml
+++ b/openapi/model-service-v2.yml
@@ -179,7 +179,7 @@ paths:
           schema:
             $ref: '#/components/schemas/ModelIdentifier'
       responses:
-        "200":
+        "204":
           description: successful operation
       security:
         - Bearer: []
@@ -304,7 +304,7 @@ paths:
             type: boolean
             default: False
       responses:
-        '200':
+        '204':
           description: successful operation
       security:
         - Bearer: []
@@ -570,7 +570,7 @@ paths:
           schema:
             $ref: '#/components/schemas/RecordIdentifier'
       responses:
-        '200':
+        '204':
           description: successful operation
           # schema:
           #   $ref: '#/components/schemas/Record'


### PR DESCRIPTION
Connexion now returns 204, No Content, for deletes with handlers that do not return a value. This PR updates our OpenAPI specs to reflect the change.