### PR TITLE
Filter 'id' from Model Json bodies before passing to Python methods

### DIFF
--- a/server/api/v1/common.py
+++ b/server/api/v1/common.py
@@ -39,7 +39,7 @@ NULL_UUID = UUID(int=0)
 
 
 def filter_model_dict(body: JsonDict) -> JsonDict:
-    return {decamelize(k): v for k, v in body.items() if k in Model.PUBLIC_CAMEL}
+    return {decamelize(k): v for k, v in body.items() if k in Model.REST_REQUEST_MODEL}
 
 
 def to_concept_dict(m: Model, property_count: int) -> JsonDict:

--- a/server/models/models.py
+++ b/server/models/models.py
@@ -411,11 +411,11 @@ class Model(FromNodeMixin, Serializable):
 
     __schema__: ClassVar[ModelSchema] = ModelSchema(unknown=marshmallow.EXCLUDE)
 
-    PUBLIC_CAMEL: ClassVar[Set[str]] = set(
-        ["id", "name", "displayName", "description", "templateId"]
+    REST_REQUEST_MODEL: ClassVar[Set[str]] = set(
+        ["name", "displayName", "description", "templateId"]
     )
 
-    PUBLIC: ClassVar[Set[str]] = humps.decamelize(PUBLIC_CAMEL)
+    PUBLIC: ClassVar[Set[str]] = set(["id"]).union(humps.decamelize(REST_REQUEST_MODEL))
 
     id: t.ModelId
     name: str


### PR DESCRIPTION
Prior to #12 if Model create/update request bodies contained the Json key `id`, this key/value pair was not passed to Python code because Connexion changed `id` to `id_` and we filtered it out. This was desirable because our related Python methods do not have an `id` argument.

At some point Connexion realized that it was a bug on their part to modify the keys of Json request bodies in any way and fixed this in later versions. Starting with #12 we are using a Connexion version which includes this bug fix, and so the `id` key is no longer being renamed. This PR fixes our Json-to-Python-arg-list filtering to once again remove `id` before it gets to our Python methods.