### PR TITLE
868fq7cwe conditional metadata migration and record package export

### DIFF
--- a/publish/__main__.py
+++ b/publish/__main__.py
@@ -101,7 +101,12 @@ parser.add_argument(
     help="AWS S3 target bucket, either for embargoed or published datasets",
     action=env_action("S3_BUCKET"),
 )
-
+parser.add_argument(
+    "--metadata-migration",
+    action="store_true",
+    default=("METADATA_MIGRATION" in environ),
+    help="publish specific for metadata migration",
+)
 
 if __name__ == "__main__":
     configure_logging("INFO")
@@ -117,9 +122,12 @@ if __name__ == "__main__":
 
     s3 = boto3.client("s3", region_name="us-east-1")
 
-    config = PublishConfig(s3_publish_key=args.s3_publish_key, s3_bucket=args.s3_bucket)
+    config = PublishConfig(s3_publish_key=args.s3_publish_key, s3_bucket=args.s3_bucket, metadata_migration=args.metadata_migration)
 
-    file_manifests = read_file_manifests(s3, config)
+    # only fetch manifest files for publish
+    file_manifests = []
+    if !config.metadata_migration:
+        file_manifests = read_file_manifests(s3, config)
 
     graph_manifests = publish_dataset(db, s3, config, file_manifests=file_manifests)
 

--- a/publish/config.py
+++ b/publish/config.py
@@ -3,8 +3,8 @@ from dataclasses import dataclass
 
 from core import Config
 
-
 @dataclass(frozen=True)
 class PublishConfig(Config):
     s3_bucket: str
     s3_publish_key: str
+    metadata_migration: bool

--- a/publish/publish.py
+++ b/publish/publish.py
@@ -463,8 +463,8 @@ def publish_package_proxy_files(
     )
 
 def package_proxy_relationships(
-  package_proxies: Iterator[Tuple[PackageProxy, Record]],
-  file_manifests: List[FileManifest],
+    package_proxies: Iterator[Tuple[PackageProxy, Record]],
+    file_manifests: List[FileManifest],
 ) -> Iterator[PackageProxyRelationship]:
     """
     Yield all proxy package relationships in the dataset
@@ -473,16 +473,16 @@ def package_proxy_relationships(
     longer exists in the dataset, ignore it.
     """
     files_by_package_id: Dict[str, List[FileManifest]] = defaultdict(list)
-    for file_manifest in file_manifests:
-        if file_manifest.source_package_id:
-            files_by_package_id[file_manifest.source_package_id].append(file_manifest)
+    for f in file_manifests:
+        if f.source_package_id:
+            files_by_package_id[f.source_package_id].append(f)
 
     for pp, record in package_proxies:
         for file_manifest in files_by_package_id.get(pp.package_node_id, []):
             assert file_manifest.id is not None
 
             yield PackageProxyRelationship(
-                from_=record.id, to=file_manifest.id, relationship=pp.relationship_type,
+                from_=record.id, to=file_manifest.id, relationship=pp.relationship_type
             )
 
 def publish_relationships(

--- a/publish/publish.py
+++ b/publish/publish.py
@@ -153,13 +153,13 @@ def read_file_manifests(s3, config: PublishConfig) -> List[FileManifest]:
     """
     log.info("Reading source file manifests")
 
-        body = s3.get_object(
-            Bucket=config.s3_bucket,
-            Key=str(PUBLISH_ASSETS_FILE.with_prefix(config.s3_publish_key)),
-            RequestPayer="requester",
-        )["Body"].read()
+    body = s3.get_object(
+        Bucket=config.s3_bucket,
+        Key=str(PUBLISH_ASSETS_FILE.with_prefix(config.s3_publish_key)),
+        RequestPayer="requester",
+    )["Body"].read()
 
-        return FileManifest.schema().load(json.loads(body)["packageManifests"], many=True)
+    return FileManifest.schema().load(json.loads(body)["packageManifests"], many=True)
 
 
 def write_graph_manifests(

--- a/publish/publish.py
+++ b/publish/publish.py
@@ -472,6 +472,7 @@ def package_proxy_relationships(
     Explodes each proxy package into multiple source files.  If the package no
     longer exists in the dataset, ignore it.
     """
+
     files_by_package_id: Dict[str, List[FileManifest]] = defaultdict(list)
     for f in file_manifests:
         if f.source_package_id:
@@ -484,6 +485,7 @@ def package_proxy_relationships(
             yield PackageProxyRelationship(
                 from_=record.id, to=file_manifest.id, relationship=pp.relationship_type
             )
+
 
 def publish_relationships(
     db: PartitionedDatabase,
@@ -543,7 +545,11 @@ def publish_relationships(
         s3_version_id = version_of(s3, config.s3_bucket, output_file)
     )
 
-def publish_record_packages(config, s3, record_packages: Iterator[Tuple[PackageProxy, Record]]) -> FileManifest:
+def publish_record_packages(
+    config,
+    s3,
+    record_packages: Iterator[Tuple[PackageProxy, Record]],
+) -> FileManifest:
     """
     Export all record package relationships into a CSV
     """

--- a/publish/publish.py
+++ b/publish/publish.py
@@ -6,7 +6,7 @@ import sys
 from collections import Sequence, Set, defaultdict
 from contextlib import contextmanager
 from datetime import datetime
-from itertools import chain
+from itertools import chain, tee
 from tempfile import NamedTemporaryFile
 from typing import Dict, Iterator, List, Optional, Set, Tuple, Union, cast
 from uuid import UUID
@@ -54,7 +54,7 @@ PUBLISH_ASSETS_FILE = OutputFile.json("publish")
 
 GRAPH_ASSETS_FILE = OutputFile.json("graph")
 
-DATASET_LOCATION_FILE = OutputFile.json("service")
+RECORD_PACKAGES_FILE = OutputFile.csv_for_model("record_packages")
 
 PROXY_FILE_MODEL_NAME = "file"
 
@@ -78,10 +78,12 @@ def publish_dataset(
 
         # 0) Get all existing proxy relationships. We'll need these in a few places.
         # ======================================================================
+        record_packages, package_proxies = package_proxies_and_relationships(db, tx, file_manifests)
+
         proxies_by_relationship: Dict[
             RelationshipName, List[PackageProxyRelationship]
         ] = defaultdict(list)
-        for pp in package_proxy_relationships(db, tx, config, s3, file_manifests):
+        for pp in package_proxies:
             proxies_by_relationship[pp.relationship].append(pp)
 
         # 1) Publish graph schema
@@ -134,6 +136,13 @@ def publish_dataset(
                 )
             )
 
+        # 5) Publish record packages (metadata migration only)
+        # ======================================================================
+        if config.metadata_migration:
+            graph_manifests.append(
+                publish_record_packages(config, s3, record_packages)
+            )
+
     return graph_manifests
 
 
@@ -144,13 +153,13 @@ def read_file_manifests(s3, config: PublishConfig) -> List[FileManifest]:
     """
     log.info("Reading source file manifests")
 
-    body = s3.get_object(
-        Bucket=config.s3_bucket,
-        Key=str(PUBLISH_ASSETS_FILE.with_prefix(config.s3_publish_key)),
-        RequestPayer="requester",
-    )["Body"].read()
+        body = s3.get_object(
+            Bucket=config.s3_bucket,
+            Key=str(PUBLISH_ASSETS_FILE.with_prefix(config.s3_publish_key)),
+            RequestPayer="requester",
+        )["Body"].read()
 
-    return FileManifest.schema().load(json.loads(body)["packageManifests"], many=True)
+        return FileManifest.schema().load(json.loads(body)["packageManifests"], many=True)
 
 
 def write_graph_manifests(
@@ -452,34 +461,36 @@ def publish_package_proxy_files(
         s3_version_id = version_of(s3, config.s3_bucket, file_output_file)
     )
 
-
-def package_proxy_relationships(
+def package_proxies_and_relationships(
     db: PartitionedDatabase,
     tx: Transaction,
-    config,
-    s3,
-    file_manifests: List[FileManifest],
-) -> Iterator[PackageProxyRelationship]:
+    file_manifests: List[FileManifest]
+) -> Tuple[Iterator[Tuple[PackageProxy, Record]], Iterator[PackageProxyRelationship]]:
     """
-    Yield all proxy package relationships in the dataset
-
-    Explodes each proxy package into multiple source files.  If the package no
-    longer exists in the dataset, ignore it.
+    Yields two iterators:
+      - All proxy packages and records in the graph -- used by the metadata migration
+      - Proxy package relationships, expanded across a package's source files,
+        only when the package exists in the dataset -- used by discover-publish
     """
+    source = db.get_all_package_proxies_tx(tx)
+    record_packages, relationships = tee(source)
 
-    files_by_package_id: Dict[str, List[FileManifest]] = defaultdict(list)
-    for f in file_manifests:
-        if f.source_package_id:
-            files_by_package_id[f.source_package_id].append(f)
+    def package_proxy_relationships() -> Iterator[PackageProxyRelationship]:
+        files_by_package_id: Dict[str, List[FileManifest]] = defaultdict(list)
+        for file_manifest in file_manifests:
+            if file_manifest.source_package_id:
+                files_by_package_id[file_manifest.source_package_id].append(file_manifest)
 
-    for pp, record in db.get_all_package_proxies_tx(tx):
-        for file_manifest in files_by_package_id.get(pp.package_node_id, []):
-            assert file_manifest.id is not None
+        for package_proxy, record in relationship_source:
+            for file_manifest in files_by_package_id.get(package_proxy.package_node_id, []):
+                assert file_manifest.id is not None
+                yield PackageProxyRelationship(
+                    from_=record.id,
+                    to=file_manifest.id,
+                    relationship=package_proxy.relationship_type,
+                )
 
-            yield PackageProxyRelationship(
-                from_=record.id, to=file_manifest.id, relationship=pp.relationship_type
-            )
-
+    return record_packages, package_proxy_relationships()
 
 def publish_relationships(
     db: PartitionedDatabase,
@@ -539,6 +550,34 @@ def publish_relationships(
         s3_version_id = version_of(s3, config.s3_bucket, output_file)
     )
 
+def publish_record_packages(config, s3, record_packages: Iterator[Tuple[PackageProxy, Record]]) -> FileManifest:
+    """
+    Export all record package relationships into a CSV
+    """
+    log.info(f"Writing record package relationships")
+
+    output_file = RECORD_PACKAGES_FILE.with_prefix(
+        os.path.join(config.s3_publish_key, METADATA)
+    )
+
+    with s3_csv_writer(
+        s3,
+        config.s3_bucket,
+        str(output_file),
+        ["record_id", "package_id", "package_node_id", "relationship_type"]
+    ) as writer:
+        for record, pp in record_packages:
+            writer.writerow([
+                str(record.id),
+                str(pp.package_id),
+                str(pp.package_node_id),
+                str(pp.relationship_type)
+            ])
+
+    return output_file.with_prefix(METADATA).as_manifest(
+        size_of(s3, config.s3_bucket, output_file),
+        s3_version_id = version_of(s3, config.s3_bucket, output_file)
+    )
 
 def size_of(s3, bucket, key) -> int:
     return s3.head_object(Bucket=bucket, Key=str(key), RequestPayer="requester")[

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -58,7 +58,7 @@ def s3(aws_credentials):
 
 @pytest.fixture(scope="session")
 def config():
-    return PublishConfig("test-embargo-bucket", "10/233")
+    return PublishConfig("test-embargo-bucket", "10/233", False)
 
 
 @pytest.fixture(scope="function")
@@ -879,7 +879,7 @@ def test_publish_linked_properties_with_no_index(
 
 
 def test_read_file_manifests(s3):
-    config = PublishConfig("test-publish-bucket", "10/233")
+    config = PublishConfig("test-publish-bucket", "10/233", False)
     s3.create_bucket(Bucket=config.s3_bucket)
 
     # This would be created by `discover-publish`
@@ -927,7 +927,7 @@ def test_read_file_manifests(s3):
 
 
 def test_write_graph_manifests(s3):
-    config = PublishConfig("test-publish-bucket", "10/233")
+    config = PublishConfig("test-publish-bucket", "10/233", False)
     s3.create_bucket(Bucket=config.s3_bucket)
 
     graph_manifests = [


### PR DESCRIPTION
## Description
**ClickUp Ticket:** [868fq7cwe](https://app.clickup.com/t/868fq7cwe)

Extends model-publish to conditionally work for the metadata migration.

The first change will be to only pull the published assets file during publish and, relatedly, always publish record/package relationships regardless of corresponding files in the published assets file.