### PR TITLE
868fq7cwe fix tuple deconstruction

### DIFF
--- a/publish/publish.py
+++ b/publish/publish.py
@@ -565,7 +565,7 @@ def publish_record_packages(
         str(output_file),
         ["record_id", "package_id", "package_node_id", "relationship_type"]
     ) as writer:
-        for record, pp in record_packages:
+        for pp, record in record_packages:
             writer.writerow([
                 str(record.id),
                 str(pp.package_id),


### PR DESCRIPTION
https://github.com/Pennsieve/model-service/pull/27 introduces a bug for metadata migration publishing that reversed the order of the tuple being used to publish record packages.

Part of debugging while testing metadata migration:
```
AttributeError: 'Record' object has no attribute 'package_id'
```