### PR TITLE
868fq7cwe extend model publish

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
       - NEO4J_BOLT_URL=bolt://neo4j-ci:7687
     depends_on:
       - neo4j-ci
-    entrypoint: "./wait-for-it.sh -t 60 neo4j-ci:7687 -- pytest -s -v --skip-integration tests"
+    entrypoint: "./wait-for-it.sh -t 60 neo4j-ci:7687 -- pytest -s -vv --skip-integration tests"
 
   model-service-lint:
     image: pennsieve/model-service-test:${IMAGE_TAG}

--- a/publish/__main__.py
+++ b/publish/__main__.py
@@ -126,7 +126,7 @@ if __name__ == "__main__":
 
     # only fetch manifest files for publish
     file_manifests = []
-    if !config.metadata_migration:
+    if not config.metadata_migration:
         file_manifests = read_file_manifests(s3, config)
 
     graph_manifests = publish_dataset(db, s3, config, file_manifests=file_manifests)

--- a/publish/models.py
+++ b/publish/models.py
@@ -98,6 +98,9 @@ class ExportModelPropertySchema(CamelCaseSchema):
         serialize=lambda o: o.data_type.to_dict(),
         deserialize=dt.deserialize,
     )
+    default_value = fields.Raw()
+    required = fields.Boolean()
+    model_title = fields.Boolean()
 
 
 @dataclass(frozen=True)
@@ -111,6 +114,9 @@ class ExportModelProperty(ExportProperty):
     display_name: str
     description: str
     data_type: dt.DataType
+    default_value: Optional[t.GraphValue] = field(default=None)
+    required: bool = False
+    model_title: bool = False
 
 
 class LinkedModelDataTypeSchema(CamelCaseSchema):

--- a/publish/publish.py
+++ b/publish/publish.py
@@ -216,6 +216,8 @@ def publish_schema(
                 display_name=p.display_name,
                 description=p.description,
                 data_type=p.data_type,
+                required=p.required,
+                model_title=p.model_title,
             )
             for p in properties
         ] + [

--- a/publish/publish.py
+++ b/publish/publish.py
@@ -573,7 +573,7 @@ def publish_record_packages(
         str(output_file),
         ["record_id", "package_id", "package_node_id", "relationship_type"]
     ) as writer:
-        for record, pp in record_packages:
+        for pp, record in record_packages:
             writer.writerow([
                 str(record.id),
                 str(pp.package_id),

--- a/publish/publish.py
+++ b/publish/publish.py
@@ -216,6 +216,7 @@ def publish_schema(
                 display_name=p.display_name,
                 description=p.description,
                 data_type=p.data_type,
+                default_value=p.default_value,
                 required=p.required,
                 model_title=p.model_title,
             )

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -200,6 +200,8 @@ def test_publish(
                     "displayName": "Name",
                     "description": "",
                     "dataType": {"type": "String"},
+                    "required": False,
+                    "modelTitle": True,
                 }
             ],
         },
@@ -214,6 +216,8 @@ def test_publish(
                     "displayName": "Path",
                     "description": "The path to the file from the root of the dataset",
                     "dataType": {"type": "String"},
+                    "required": False,
+                    "modelTitle": True,
                 }
                 # TODO: add sourcePackageId (enhancement)
             ],
@@ -229,6 +233,8 @@ def test_publish(
                     "displayName": "Name",
                     "description": "",
                     "dataType": {"type": "String"},
+                    "required": False,
+                    "modelTitle": True,
                 }
             ],
         },
@@ -243,12 +249,16 @@ def test_publish(
                     "displayName": "Name",
                     "description": "",
                     "dataType": {"type": "String"},
+                    "required": False,
+                    "modelTitle": True,
                 },
                 {
                     "name": "age",
                     "displayName": "Age",
                     "description": "",
                     "dataType": {"type": "Long"},
+                    "required": False,
+                    "modelTitle": False,
                 },
                 {
                     "name": "best_friend",
@@ -259,6 +269,8 @@ def test_publish(
                         "to": "patient",
                         "file": "records/patient.csv",
                     },
+                    "required": False,
+                    "modelTitle": False,
                 },
             ],
         },
@@ -273,6 +285,8 @@ def test_publish(
                     "displayName": "Day",
                     "description": "",
                     "dataType": {"type": "String"},
+                    "required": False,
+                    "modelTitle": True,
                 }
             ],
         },
@@ -826,18 +840,24 @@ def test_publish_linked_properties_with_no_index(
             "displayName": "name",
             "description": "",
             "dataType": {"type": "String"},
+            "required": False,
+            "modelTitle": True,
         },
         {
             "name": "interacts",
             "displayName": "interacts",
             "description": "",
             "dataType": {"type": "Model", "to": "gene", "file": "records/gene.csv"},
+            "required": False,
+            "modelTitle": False,
         },
         {
             "name": "regulates",
             "displayName": "regulates",
             "description": "",
             "dataType": {"type": "Model", "to": "gene", "file": "records/gene.csv"},
+            "required": False,
+            "modelTitle": False,
         },
     ]
 

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -269,8 +269,6 @@ def test_publish(
                         "to": "patient",
                         "file": "records/patient.csv",
                     },
-                    "required": False,
-                    "modelTitle": False,
                 },
             ],
         },
@@ -848,16 +846,12 @@ def test_publish_linked_properties_with_no_index(
             "displayName": "interacts",
             "description": "",
             "dataType": {"type": "Model", "to": "gene", "file": "records/gene.csv"},
-            "required": False,
-            "modelTitle": False,
         },
         {
             "name": "regulates",
             "displayName": "regulates",
             "description": "",
             "dataType": {"type": "Model", "to": "gene", "file": "records/gene.csv"},
-            "required": False,
-            "modelTitle": False,
         },
     ]
 

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -217,7 +217,7 @@ def test_publish(
                     "description": "The path to the file from the root of the dataset",
                     "dataType": {"type": "String"},
                     "required": False,
-                    "modelTitle": True,
+                    "modelTitle": False,
                 }
                 # TODO: add sourcePackageId (enhancement)
             ],
@@ -840,7 +840,7 @@ def test_publish_linked_properties_with_no_index(
             "displayName": "name",
             "description": "",
             "dataType": {"type": "String"},
-            "required": False,
+            "required": True,
             "modelTitle": True,
         },
         {


### PR DESCRIPTION
## Description
**ClickUp Ticket:** [868fq7cwe](https://app.clickup.com/t/868fq7cwe)

Adds:
- `required`, `model_title` (primary key), and `default_value` to `schema.json` export.
- emits lists as JSON arrays for metadata migration so fidelity isn't lost. 